### PR TITLE
✨ feat(spark-multiply): auto-buy/sell ops for adjust up/down on spark

### DIFF
--- a/packages/deploy-configurations/constants/contract-names.arbitrum.ts
+++ b/packages/deploy-configurations/constants/contract-names.arbitrum.ts
@@ -3,6 +3,7 @@ export const SERVICE_REGISTRY_NAMES = {
   common: {
     PULL_TOKEN: 'PullToken_7',
     SEND_TOKEN: 'SendToken_7',
+    SEND_TOKEN_AUTO: 'SendTokenAuto_7',
     SET_APPROVAL: 'SetApproval_6',
     TAKE_A_FLASHLOAN: 'TakeFlashloan_6',
     TAKE_A_FLASHLOAN_BALANCER: 'TakeFlashloanBalancer_3',

--- a/packages/deploy-configurations/constants/contract-names.base.ts
+++ b/packages/deploy-configurations/constants/contract-names.base.ts
@@ -3,6 +3,7 @@ export const SERVICE_REGISTRY_NAMES = {
   common: {
     PULL_TOKEN: 'PullToken_7',
     SEND_TOKEN: 'SendToken_7',
+    SEND_TOKEN_AUTO: 'SendTokenAuto_7',
     SET_APPROVAL: 'SetApproval_6',
     TAKE_A_FLASHLOAN: 'TakeFlashloan_6',
     TAKE_A_FLASHLOAN_BALANCER: 'TakeFlashloanBalancer_3',

--- a/packages/deploy-configurations/constants/contract-names.mainnet.ts
+++ b/packages/deploy-configurations/constants/contract-names.mainnet.ts
@@ -3,6 +3,7 @@ export const SERVICE_REGISTRY_NAMES = {
   common: {
     PULL_TOKEN: 'PullToken_7',
     SEND_TOKEN: 'SendToken_7',
+    SEND_TOKEN_AUTO: 'SendTokenAuto_7',
     SET_APPROVAL: 'SetApproval_6',
     TAKE_A_FLASHLOAN: 'TakeFlashloan_6',
     TAKE_A_FLASHLOAN_BALANCER: 'TakeFlashloanBalancer_3',

--- a/packages/deploy-configurations/constants/contract-names.optimism.ts
+++ b/packages/deploy-configurations/constants/contract-names.optimism.ts
@@ -3,6 +3,7 @@ export const SERVICE_REGISTRY_NAMES = {
   common: {
     PULL_TOKEN: 'PullToken_7',
     SEND_TOKEN: 'SendToken_7',
+    SEND_TOKEN_AUTO: 'SendTokenAuto_7',
     SET_APPROVAL: 'SetApproval_6',
     TAKE_A_FLASHLOAN: 'TakeFlashloan_6',
     TAKE_A_FLASHLOAN_BALANCER: 'TakeFlashloanBalancer_3',

--- a/packages/deploy-configurations/operation-definitions/spark/multiply/adjust-down.ts
+++ b/packages/deploy-configurations/operation-definitions/spark/multiply/adjust-down.ts
@@ -33,10 +33,6 @@ export function getSparkAdjustDownOperationDefinition(network: Network) {
         optional: false,
       },
       {
-        hash: getActionHash(SERVICE_REGISTRY_NAMES.common.UNWRAP_ETH),
-        optional: true,
-      },
-      {
         hash: getActionHash(SERVICE_REGISTRY_NAMES.common.RETURN_FUNDS),
         optional: false,
       },

--- a/packages/deploy-configurations/operation-definitions/spark/multiply/adjust-down.ts
+++ b/packages/deploy-configurations/operation-definitions/spark/multiply/adjust-down.ts
@@ -29,7 +29,7 @@ export function getSparkAdjustDownOperationDefinition(network: Network) {
         optional: false,
       },
       {
-        hash: getActionHash(SERVICE_REGISTRY_NAMES.common.SEND_TOKEN),
+        hash: getActionHash(SERVICE_REGISTRY_NAMES.common.SEND_TOKEN_AUTO),
         optional: false,
       },
       {

--- a/packages/deploy-configurations/operation-definitions/spark/multiply/adjust-down.ts
+++ b/packages/deploy-configurations/operation-definitions/spark/multiply/adjust-down.ts
@@ -9,7 +9,7 @@ export function getSparkAdjustDownOperationDefinition(network: Network) {
     name: OPERATION_NAMES.spark.ADJUST_RISK_DOWN,
     actions: [
       {
-        hash: getActionHash(SERVICE_REGISTRY_NAMES.common.TAKE_A_FLASHLOAN),
+        hash: getActionHash(SERVICE_REGISTRY_NAMES.common.TAKE_A_FLASHLOAN_BALANCER),
         optional: false,
       },
       {

--- a/packages/deploy-configurations/operation-definitions/spark/multiply/adjust-up.ts
+++ b/packages/deploy-configurations/operation-definitions/spark/multiply/adjust-up.ts
@@ -37,7 +37,7 @@ export function getSparkAdjustUpOperationDefinition(network: Network) {
         optional: false,
       },
       {
-        hash: getActionHash(SERVICE_REGISTRY_NAMES.common.SEND_TOKEN),
+        hash: getActionHash(SERVICE_REGISTRY_NAMES.common.SEND_TOKEN_AUTO),
         optional: false,
       },
     ],

--- a/packages/deploy-configurations/operation-definitions/spark/multiply/adjust-up.ts
+++ b/packages/deploy-configurations/operation-definitions/spark/multiply/adjust-up.ts
@@ -9,7 +9,7 @@ export function getSparkAdjustUpOperationDefinition(network: Network) {
     name: OPERATION_NAMES.spark.ADJUST_RISK_UP,
     actions: [
       {
-        hash: getActionHash(SERVICE_REGISTRY_NAMES.common.TAKE_A_FLASHLOAN),
+        hash: getActionHash(SERVICE_REGISTRY_NAMES.common.TAKE_A_FLASHLOAN_BALANCER),
         optional: false,
       },
       {

--- a/packages/deploy-configurations/operation-definitions/spark/multiply/adjust-up.ts
+++ b/packages/deploy-configurations/operation-definitions/spark/multiply/adjust-up.ts
@@ -14,11 +14,7 @@ export function getSparkAdjustUpOperationDefinition(network: Network) {
       },
       {
         hash: getActionHash(SERVICE_REGISTRY_NAMES.common.PULL_TOKEN),
-        optional: true,
-      },
-      {
-        hash: getActionHash(SERVICE_REGISTRY_NAMES.common.WRAP_ETH),
-        optional: true,
+        optional: false,
       },
       {
         hash: getActionHash(SERVICE_REGISTRY_NAMES.common.SWAP_ACTION),

--- a/packages/dma-contracts/contracts/actions/aave/v3/WithdrawAuto.sol
+++ b/packages/dma-contracts/contracts/actions/aave/v3/WithdrawAuto.sol
@@ -14,7 +14,7 @@ import { ServiceRegistry } from "../../../core/ServiceRegistry.sol";
 /**
  * @title Withdraw | AAVE V3 Action contract
  * @notice Withdraw collateral from AAVE's lending pool
- * with the amount to withdraw being read from a storage slot
+ * with the amount to withdraw being read from an OperationStorage slot
  */
 contract AaveV3WithdrawAuto is Executable, UseStorageSlot, UseRegistry {
   using Write for StorageSlot.TransactionStorage;

--- a/packages/dma-contracts/contracts/actions/aave/v3/WithdrawAuto.sol
+++ b/packages/dma-contracts/contracts/actions/aave/v3/WithdrawAuto.sol
@@ -14,6 +14,7 @@ import { ServiceRegistry } from "../../../core/ServiceRegistry.sol";
 /**
  * @title Withdraw | AAVE V3 Action contract
  * @notice Withdraw collateral from AAVE's lending pool
+ * with the amount to withdraw being read from a storage slot
  */
 contract AaveV3WithdrawAuto is Executable, UseStorageSlot, UseRegistry {
   using Write for StorageSlot.TransactionStorage;

--- a/packages/dma-contracts/contracts/actions/aave/v3/WithdrawAuto.sol
+++ b/packages/dma-contracts/contracts/actions/aave/v3/WithdrawAuto.sol
@@ -14,7 +14,6 @@ import { ServiceRegistry } from "../../../core/ServiceRegistry.sol";
 /**
  * @title Withdraw | AAVE V3 Action contract
  * @notice Withdraw collateral from AAVE's lending pool
- * with the amount to withdraw being read from a storage slot
  */
 contract AaveV3WithdrawAuto is Executable, UseStorageSlot, UseRegistry {
   using Write for StorageSlot.TransactionStorage;

--- a/packages/dma-contracts/contracts/actions/common/SendTokenAuto.sol
+++ b/packages/dma-contracts/contracts/actions/common/SendTokenAuto.sol
@@ -12,7 +12,7 @@ import { UseRegistry } from "../../libs/UseRegistry.sol";
 /**
  * @title SendToken Action contract
  * @notice Transfer token from the calling contract to the destination address
- * with the amount to send being read from a storage slot
+ * with the amount to send being read from an OperationStorage slot
  */
 contract SendToken is Executable, UseStorageSlot, UseRegistry {
   using SafeERC20 for IERC20;

--- a/packages/dma-contracts/contracts/actions/common/SendTokenAuto.sol
+++ b/packages/dma-contracts/contracts/actions/common/SendTokenAuto.sol
@@ -25,7 +25,7 @@ contract SendToken is Executable, UseStorageSlot, UseRegistry {
    */
   function execute(bytes calldata data, uint8[] memory paramsMap) external payable override {
     SendTokenData memory send = parseInputs(data);
-    // Note: bytes32(0) meaning no amount passed directly in calldata can be used
+    // Note: bytes32(0) indicates no amount passed as an arg in calldata can be used
     send.amount = store().readUint(bytes32(0), paramsMap[2]);
 
     if (send.asset != ETH) {

--- a/packages/dma-contracts/contracts/actions/common/SendTokenAuto.sol
+++ b/packages/dma-contracts/contracts/actions/common/SendTokenAuto.sol
@@ -12,6 +12,7 @@ import { UseRegistry } from "../../libs/UseRegistry.sol";
 /**
  * @title SendToken Action contract
  * @notice Transfer token from the calling contract to the destination address
+ * with the amount to send being read from a storage slot
  */
 contract SendToken is Executable, UseStorageSlot, UseRegistry {
   using SafeERC20 for IERC20;
@@ -24,7 +25,8 @@ contract SendToken is Executable, UseStorageSlot, UseRegistry {
    */
   function execute(bytes calldata data, uint8[] memory paramsMap) external payable override {
     SendTokenData memory send = parseInputs(data);
-    send.amount = store().readUint(bytes32(send.amount), paramsMap[2]);
+    // Note: bytes32(0) meaning no amount passed directly in calldata can be used
+    send.amount = store().readUint(bytes32(0), paramsMap[2]);
 
     if (send.asset != ETH) {
       if (send.amount == type(uint256).max) {

--- a/packages/dma-contracts/contracts/actions/common/SendTokenAuto.sol
+++ b/packages/dma-contracts/contracts/actions/common/SendTokenAuto.sol
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+pragma solidity ^0.8.15;
+
+import { Executable } from "../common/Executable.sol";
+import { SafeERC20, IERC20 } from "../../libs/SafeERC20.sol";
+import { SendTokenData } from "../../core/types/Common.sol";
+import { UseStorageSlot, StorageSlot, Write, Read } from "../../libs/UseStorageSlot.sol";
+import { ServiceRegistry } from "../../core/ServiceRegistry.sol";
+import { ETH } from "../../core/constants/Common.sol";
+import { UseRegistry } from "../../libs/UseRegistry.sol";
+
+/**
+ * @title SendToken Action contract
+ * @notice Transfer token from the calling contract to the destination address
+ */
+contract SendToken is Executable, UseStorageSlot, UseRegistry {
+  using SafeERC20 for IERC20;
+  using Read for StorageSlot.TransactionStorage;
+
+  constructor(address _registry) UseRegistry(ServiceRegistry(_registry)) {}
+  
+  /**
+   * @param data Encoded calldata that conforms to the SendTokenData struct
+   */
+  function execute(bytes calldata data, uint8[] memory paramsMap) external payable override {
+    SendTokenData memory send = parseInputs(data);
+    send.amount = store().readUint(bytes32(send.amount), paramsMap[2]);
+
+    if (send.asset != ETH) {
+      if (send.amount == type(uint256).max) {
+        send.amount = IERC20(send.asset).balanceOf(address(this));
+      }
+      IERC20(send.asset).safeTransfer(send.to, send.amount);
+    } else {
+      if (send.amount == type(uint256).max) {
+        send.amount = address(this).balance;
+      }
+      payable(send.to).transfer(send.amount);
+    }
+  }
+
+  function parseInputs(bytes memory _callData) public pure returns (SendTokenData memory params) {
+    return abi.decode(_callData, (SendTokenData));
+  }
+}

--- a/packages/dma-contracts/contracts/actions/common/TakeFlashloanBalancer.sol
+++ b/packages/dma-contracts/contracts/actions/common/TakeFlashloanBalancer.sol
@@ -56,7 +56,7 @@ contract TakeFlashloanBalancer is Executable, ProxyPermission, UseStorageSlot, U
     uint256 feePercentage = IProtocolFeesCollector(
       IVault(getRegisteredService(BALANCER_VAULT)).getProtocolFeesCollector()
     ).getFlashLoanFeePercentage();
-    if( feePercentage > 0) {
+    if (feePercentage > 0) {
       uint256 fullFlashloanAmount = amounts[0] + FixedPoint.mulUp(amounts[0], feePercentage);
       store().write(bytes32(fullFlashloanAmount));
     } else {

--- a/packages/dma-contracts/contracts/actions/spark/WithdrawAuto.sol
+++ b/packages/dma-contracts/contracts/actions/spark/WithdrawAuto.sol
@@ -13,7 +13,7 @@ import { ServiceRegistry } from "../../../core/ServiceRegistry.sol";
 /**
  * @title Withdraw | Spark Action contract
  * @notice Withdraw collateral from Spark's lending pool
- * with the amount to withdraw being read from a storage slot
+ * with the amount to withdraw being read from an OperationStorage slot
  */
 contract SparkWithdrawAuto is Executable, UseStorageSlot, UseRegistry {
   using Write for StorageSlot.TransactionStorage;

--- a/packages/dma-library/src/actions/common.ts
+++ b/packages/dma-library/src/actions/common.ts
@@ -104,24 +104,24 @@ export function sendToken(
 }
 
 export function sendTokenAuto(
-    network: Network,
-    args: { asset: string; to: string; amount: BigNumber },
-    paramsMapping: [asset: number, to: number, amount: number] = [0, 0, 0],
+  network: Network,
+  args: { asset: string; to: string; amount: BigNumber },
+  paramsMapping: [asset: number, to: number, amount: number] = [0, 0, 0],
 ) {
-    const SERVICE_REGISTRY_NAMES = loadContractNames(network)
+  const SERVICE_REGISTRY_NAMES = loadContractNames(network)
 
-    return createAction(
-        getActionHash(SERVICE_REGISTRY_NAMES.common.SEND_TOKEN),
-        [calldataTypes.common.SendToken],
-        [
-            {
-                asset: args.asset,
-                to: args.to,
-                amount: args.amount.toFixed(0),
-            },
-            paramsMapping,
-        ],
-    )
+  return createAction(
+    getActionHash(SERVICE_REGISTRY_NAMES.common.SEND_TOKEN_AUTO),
+    [calldataTypes.common.SendToken],
+    [
+      {
+        asset: args.asset,
+        to: 0, // always taken from mapping
+        amount: args.amount.toFixed(0),
+      },
+      paramsMapping,
+    ],
+  )
 }
 
 export function takeAFlashLoan(

--- a/packages/dma-library/src/actions/common.ts
+++ b/packages/dma-library/src/actions/common.ts
@@ -103,6 +103,27 @@ export function sendToken(
   )
 }
 
+export function sendTokenAuto(
+    network: Network,
+    args: { asset: string; to: string; amount: BigNumber },
+    paramsMapping: [asset: number, to: number, amount: number] = [0, 0, 0],
+) {
+    const SERVICE_REGISTRY_NAMES = loadContractNames(network)
+
+    return createAction(
+        getActionHash(SERVICE_REGISTRY_NAMES.common.SEND_TOKEN),
+        [calldataTypes.common.SendToken],
+        [
+            {
+                asset: args.asset,
+                to: args.to,
+                amount: args.amount.toFixed(0),
+            },
+            paramsMapping,
+        ],
+    )
+}
+
 export function takeAFlashLoan(
   network: Network,
   args: {

--- a/packages/dma-library/src/actions/index.ts
+++ b/packages/dma-library/src/actions/index.ts
@@ -21,6 +21,7 @@ import {
   pullToken,
   returnFunds,
   sendToken,
+  sendTokenAuto,
   setApproval,
   swap,
   takeAFlashLoan,
@@ -56,6 +57,7 @@ const aave = {
 const common = {
   pullToken,
   sendToken,
+  sendTokenAuto,
   setApproval,
   swap,
   returnFunds,

--- a/packages/dma-library/src/operations/aave/multiply/v3/adjust-risk-down.ts
+++ b/packages/dma-library/src/operations/aave/multiply/v3/adjust-risk-down.ts
@@ -98,10 +98,6 @@ export const adjustRiskDown: AaveV3AdjustDownOperation = async ({
     },
     [1],
   )
-  //
-  // const unwrapEth = actions.common.unwrapEth(network, {
-  //   amount: new BigNumber(MAX_UINT),
-  // })
 
   const returnDebtFunds = actions.common.returnFunds(network, {
     asset: debt.address,
@@ -111,8 +107,6 @@ export const adjustRiskDown: AaveV3AdjustDownOperation = async ({
     asset: collateral.address,
   })
 
-  // unwrapEth.skipped = !debt.isEth && !collateral.isEth
-
   const flashloanCalls = [
     setFlashloanTokenApprovalOnLendingPool,
     depositFlashloanTokenInAave,
@@ -121,7 +115,6 @@ export const adjustRiskDown: AaveV3AdjustDownOperation = async ({
     setDebtTokenApprovalOnLendingPool,
     paybackInAAVE,
     withdrawFlashloanTokenFromAave,
-    // unwrapEth,
     returnDebtFunds,
     returnCollateralFunds,
   ]

--- a/packages/dma-library/src/operations/aave/multiply/v3/adjust-risk-down.ts
+++ b/packages/dma-library/src/operations/aave/multiply/v3/adjust-risk-down.ts
@@ -89,6 +89,7 @@ export const adjustRiskDown: AaveV3AdjustDownOperation = async ({
     [0, 4, 0],
   )
 
+  const flashloanActionStorageIndex = 1
   const withdrawFlashloanTokenFromAave = actions.aave.v3.aaveV3WithdrawAuto(
     network,
     {
@@ -96,7 +97,7 @@ export const adjustRiskDown: AaveV3AdjustDownOperation = async ({
       amount: flashloan.token.amount,
       to: addresses.operationExecutor,
     },
-    [1],
+    [flashloanActionStorageIndex],
   )
 
   const returnDebtFunds = actions.common.returnFunds(network, {

--- a/packages/dma-library/src/operations/aave/multiply/v3/adjust-risk-down.ts
+++ b/packages/dma-library/src/operations/aave/multiply/v3/adjust-risk-down.ts
@@ -1,4 +1,5 @@
 import { getAaveAdjustDownV3OperationDefinition } from '@deploy-configurations/operation-definitions'
+import {ZERO} from "@dma-common/constants";
 import { actions } from '@dma-library/actions'
 import { IOperation } from '@dma-library/types'
 import {
@@ -94,7 +95,7 @@ export const adjustRiskDown: AaveV3AdjustDownOperation = async ({
     network,
     {
       asset: flashloan.token.address,
-      amount: flashloan.token.amount,
+      amount: ZERO, // Is taken from mapping
       to: addresses.operationExecutor,
     },
     [flashloanActionStorageIndex],

--- a/packages/dma-library/src/operations/aave/multiply/v3/adjust-risk-up.ts
+++ b/packages/dma-library/src/operations/aave/multiply/v3/adjust-risk-up.ts
@@ -110,23 +110,20 @@ export const adjustRiskUp: AaveV3AdjustUpOperation = async ({
     [0, 4, 0, 0],
   )
 
-  const withdrawFlashloan = actions.aave.v3.aaveV3WithdrawAuto(network, {
-    asset: flashloan.token.address,
-    amount: flashloan.token.amount,
-    to: addresses.operationExecutor,
-  },
-    [1]
+  const withdrawFlashloan = actions.aave.v3.aaveV3WithdrawAuto(
+    network,
+    {
+      asset: flashloan.token.address,
+      amount: flashloan.token.amount,
+      to: addresses.operationExecutor,
+    },
+    [1],
   )
 
-  // pullDepositTokensToProxy.skipped = depositAmount.eq(ZERO) || debt.isEth
-  // wrapEth.skipped = !debt.isEth && !collateral.isEth
-
   const flashloanCalls = [
-    // pullDepositTokensToProxy,
     setFlashLoanApproval,
     depositFlashloan,
     borrowDebtTokensFromAAVE,
-    // wrapEth,
     swapDebtTokensForCollateralTokens,
     setCollateralTokenApprovalOnLendingPool,
     depositCollateral,

--- a/packages/dma-library/src/operations/aave/multiply/v3/adjust-risk-up.ts
+++ b/packages/dma-library/src/operations/aave/multiply/v3/adjust-risk-up.ts
@@ -48,12 +48,6 @@ export const adjustRiskUp: AaveV3AdjustUpOperation = async ({
   const depositAmount = deposit?.amount || ZERO
   const depositAddress = deposit?.address || NULL_ADDRESS
 
-  // const pullDepositTokensToProxy = actions.common.pullToken(network, {
-  //   asset: depositAddress,
-  //   amount: depositAmount,
-  //   from: proxy.owner,
-  // })
-
   const setFlashLoanApproval = actions.common.setApproval(network, {
     amount: flashloan.token.amount,
     asset: flashloan.token.address,
@@ -71,10 +65,6 @@ export const adjustRiskUp: AaveV3AdjustUpOperation = async ({
     amount: debt.borrow.amount,
     asset: debt.address,
     to: proxy.address,
-  })
-
-  const wrapEth = actions.common.wrapEth(network, {
-    amount: new BigNumber(ethers.constants.MaxUint256.toHexString()),
   })
 
   const swapDebtTokensForCollateralTokens = actions.common.swap(network, {
@@ -114,7 +104,7 @@ export const adjustRiskUp: AaveV3AdjustUpOperation = async ({
     network,
     {
       asset: flashloan.token.address,
-      amount: flashloan.token.amount,
+      amount: ZERO, // Is taken from mapping
       to: addresses.operationExecutor,
     },
     [1],

--- a/packages/dma-library/src/operations/spark/multiply/adjust-risk-down.ts
+++ b/packages/dma-library/src/operations/spark/multiply/adjust-risk-down.ts
@@ -79,6 +79,7 @@ export const adjustRiskDown: SparkAdjustDownOperation = async ({
 
   // Param Map [0, 0, 1 (amount)] is used to indicate that the flash-loaned amount
   // should be sent to the operation executor
+  const flashloanActionStorageIndex = 1
   const sendDebtTokenToOpExecutor = actions.common.sendToken(
     network,
     {
@@ -86,7 +87,7 @@ export const adjustRiskDown: SparkAdjustDownOperation = async ({
       to: addresses.operationExecutor,
       amount: flashloan.token.amount.plus(BALANCER_FEE.div(FEE_BASE).times(flashloan.token.amount)),
     },
-    [0, 0, 1],
+    [0, 0, flashloanActionStorageIndex],
   )
 
   const returnDebtFunds = actions.common.returnFunds(network, {

--- a/packages/dma-library/src/operations/spark/multiply/adjust-risk-down.ts
+++ b/packages/dma-library/src/operations/spark/multiply/adjust-risk-down.ts
@@ -1,5 +1,5 @@
 import { getSparkAdjustDownOperationDefinition } from '@deploy-configurations/operation-definitions'
-import { FEE_BASE } from '@dma-common/constants'
+import {FEE_BASE, ZERO} from '@dma-common/constants'
 import { actions } from '@dma-library/actions'
 import { BALANCER_FEE } from '@dma-library/config/flashloan-fees'
 import { IOperation } from '@dma-library/types'
@@ -80,12 +80,12 @@ export const adjustRiskDown: SparkAdjustDownOperation = async ({
   // Param Map [0, 0, 1 (amount)] is used to indicate that the flash-loaned amount
   // should be sent to the operation executor
   const flashloanActionStorageIndex = 1
-  const sendDebtTokenToOpExecutor = actions.common.sendToken(
+  const sendDebtTokenToOpExecutor = actions.common.sendTokenAuto(
     network,
     {
       asset: debt.address,
       to: addresses.operationExecutor,
-      amount: flashloan.token.amount.plus(BALANCER_FEE.div(FEE_BASE).times(flashloan.token.amount)),
+      amount: ZERO, // Taken from mapping
     },
     [0, 0, flashloanActionStorageIndex],
   )

--- a/packages/dma-library/src/operations/spark/multiply/adjust-risk-down.ts
+++ b/packages/dma-library/src/operations/spark/multiply/adjust-risk-down.ts
@@ -106,7 +106,7 @@ export const adjustRiskDown: SparkAdjustDownOperation = async ({
     sendDebtTokenToOpExecutor,
   ]
 
-  const takeAFlashLoan = actions.common.takeAFlashLoan(network, {
+  const takeAFlashLoan = actions.common.takeAFlashLoanBalancer(network, {
     isDPMProxy: proxy.isDPMProxy,
     asset: flashloan.token.address,
     flashloanAmount: flashloan.token.amount,

--- a/packages/dma-library/src/operations/spark/multiply/adjust-risk-up.ts
+++ b/packages/dma-library/src/operations/spark/multiply/adjust-risk-up.ts
@@ -51,10 +51,6 @@ export const adjustRiskUp: SparkAdjustUpOperation = async ({
     from: proxy.owner,
   })
 
-  const hasAmountToDeposit = depositAmount.gt(ZERO)
-  const shouldSkipPullCollateralTokensToProxy = !hasAmountToDeposit || collateral.isEth
-  pullCollateralTokensToProxy.skipped = shouldSkipPullCollateralTokensToProxy
-
   // No previous actions store values with OpStorage
   const swapActionStorageIndex = 1
   const swapDebtTokensForCollateralTokens = actions.common.swap(network, {

--- a/packages/dma-library/src/operations/spark/multiply/adjust-risk-up.ts
+++ b/packages/dma-library/src/operations/spark/multiply/adjust-risk-up.ts
@@ -96,6 +96,7 @@ export const adjustRiskUp: SparkAdjustUpOperation = async ({
     to: addresses.operationExecutor,
   })
 
+  const flashloanActionStorageIndex = 1
   const sendDebtTokenToOpExecutor = actions.common.sendToken(
     network,
     {
@@ -103,7 +104,7 @@ export const adjustRiskUp: SparkAdjustUpOperation = async ({
       to: addresses.operationExecutor,
       amount: debt.borrow.amount,
     },
-    [0, 0, 1],
+    [0, 0, flashloanActionStorageIndex],
   )
 
   const flashloanCalls = [

--- a/packages/dma-library/src/operations/spark/multiply/adjust-risk-up.ts
+++ b/packages/dma-library/src/operations/spark/multiply/adjust-risk-up.ts
@@ -97,12 +97,12 @@ export const adjustRiskUp: SparkAdjustUpOperation = async ({
   })
 
   const flashloanActionStorageIndex = 1
-  const sendDebtTokenToOpExecutor = actions.common.sendToken(
+  const sendDebtTokenToOpExecutor = actions.common.sendTokenAuto(
     network,
     {
       asset: debt.address,
       to: addresses.operationExecutor,
-      amount: debt.borrow.amount,
+      amount: ZERO, // Taken from mapping
     },
     [0, 0, flashloanActionStorageIndex],
   )


### PR DESCRIPTION
**Changes**
- Update both multiply ops to use Balancer Flashloan action that stores flashloan amount in storage
- Create SendTokenAuto action contract where amount is only set via storage
- Update Ops & Action factories accordinly
- Update op defs accordingly
- For Spark Adjust down/up - use flashloan action index to retrieve flashloan amount to send to OpExec
